### PR TITLE
Update CMake to auto-find libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,17 @@ add_executable(Mad64
 	source/chips/sid.cpp
 	source/chips/vic.cpp
 )
-	
-target_include_directories(Mad64 PUBLIC "include" , "source")
-target_link_directories(Mad64 PUBLIC "lib")
 
-target_link_libraries(Mad64 SDL2 SDL2_ttf SDL2main)
+find_package(SDL2 REQUIRED)
+find_package(SDL2_ttf REQUIRED)
+
+message(STATUS "Configuring using SDL include directories ${SDL2_INCLUDE_DIRS}")
+message(STATUS "Configuring using SDL lib directories ${SDL2_LIBRARIES}")
+
+target_link_libraries(Mad64 SDL2::SDL2)
+target_link_libraries(Mad64 SDL2_ttf)
+
+target_include_directories(Mad64 PUBLIC "include" , "source")
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${CMAKE_COMMAND} -E 
 	make_directory $<TARGET_FILE_DIR:${PROJECT_NAME}>/samples)


### PR DESCRIPTION
This should now work on all platforms that have the SDL2 and SDL2_ttf libraries correctly installed.